### PR TITLE
net: add compatibility for miniupnpc 2.2.8

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1637,7 +1637,11 @@ static void ThreadMapPort()
     struct IGDdatas data;
     int r;
 
+#if MINIUPNPC_API_VERSION <= 17
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#else
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), nullptr, 0);
+#endif
     if (r == 1)
     {
 	if (fDiscover) {


### PR DESCRIPTION
The return value of 2 now indicates:
"A valid connected IGD has been found but its IP address is reserved (non routable)"

We continue to ignore any return value other than 1.